### PR TITLE
Add `cli` cargo feature for CLI specific deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,10 @@ rand = "0.7"
 # [1]: https://github.com/briansmith/ring#versioning--stability
 ring = "0.16"
 # NOTE: The following dependencies are required only for the CLI version of the
-# crate.
-clap = "2"
-dialoguer = "0.5"
-lazy_static = "1"
+# crate, and are only included if the `cli` feature is enabled.
+clap = { version = "2", optional = true }
+dialoguer = { version = "0.5", optional = true }
+lazy_static = { version = "1", optional = true }
 
 [dev-dependencies]
 assert_cmd = "0.12"
@@ -41,5 +41,9 @@ predicates = "1"
 protoc-rust = { version = "2", optional = true }
 
 [features]
+default = ["cli"]
+
+# Dependencies needed specifically for the CLI.
+cli = ["clap", "dialoguer", "lazy_static"]
 # Generate Rust code from .proto files.
 proto-gen = ["protoc-rust"]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ assert_eq!(plaintext2, plaintext);
 
 You can find more examples in the docs section on [Tindercrypt's `RingCryptor`].
 
+When adding this crate to your `Cargo.toml`, add it with `default-features = false` (eg, `tindercrypt = { version = "x.y.z", default-features = false }`). This will ensure that the CLI specific dependencies are not added to your dependency tree.
+
 The equivalent operation in the CLI tool is the following:
 
 ```


### PR DESCRIPTION
Working as needed. Only pulls down the 3 expected deps.

<img width="433" alt="Screen Shot 2020-03-29 at 12 50 16 AM" src="https://user-images.githubusercontent.com/2380740/77842446-d8b42700-7157-11ea-8690-fd1c876879d5.png">

Closes #1 