### PR TITLE
Implement the `Error` trait using `thiserror`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versioning].
 
 ## [Unreleased]
 
+### Changed
+
+- Use the `thiserror` crate to make the library errors implement the `Error`
+  trait, and remove some boilerplate code.
+
 ## [0.2.1] - 2020-03-30
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b3d3d2ff68104100ab257bb6bb0cb26c901abe4bd4ba15961f3bf867924012"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +663,7 @@ dependencies = [
  "protoc-rust",
  "rand",
  "ring",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ rand = "0.7"
 #
 # [1]: https://github.com/briansmith/ring#versioning--stability
 ring = "0.16"
+thiserror = "1"
 
 # NOTE: The following dependencies are required only for the CLI version of the
 # crate, and are only included if the `cli` feature is enabled. See also

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,55 +1,33 @@
 //! # Tindercrypt errors
 
-use std::fmt;
+use thiserror;
 
 /// The errors that can be returned by the library.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(thiserror::Error, Copy, Clone, Debug, PartialEq)]
 pub enum Error {
     /// The provided data buffer is too small for the requested action.
+    #[error("The provided buffer is shorter than expected")]
     BufferTooSmall,
     /// The provided passphrase is too small for the key derivation process.
+    #[error("The provided passphrase is shorter than expected")]
     PassphraseTooSmall,
     /// The provided key size was not the expected one.
+    #[error(
+        "The provided key does not have the required length for the \
+         encryption algorithm"
+    )]
     KeySizeMismatch,
     /// The provided parameters to a crypto function are weak.
+    #[error("The provided parameters for the encryption are too weak")]
     CryptoParamsWeak,
     /// Could not decrypt the data, e.g., due to a bad key, wrong nonce,
     /// corrupted tag.
+    #[error("Could not decrypt the ciphertext")]
     DecryptionError,
     /// The provided buffer does not start with the expected metadata header.
+    #[error("The provided buffer does not include a metadata header")]
     MetadataMissing,
     /// The metadata header of the encrypted buffer contains invalid values.
+    #[error("The provided buffer has an invalid metadata header")]
     MetadataInvalid,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::BufferTooSmall => {
-                write!(f, "The provided buffer is shorter than expected")
-            }
-            Error::PassphraseTooSmall => {
-                write!(f, "The provided passphrase is shorter than expected")
-            }
-            Error::KeySizeMismatch => write!(
-                f,
-                "The provided key does not have the required length for the \
-                 encryption algorithm"
-            ),
-            Error::CryptoParamsWeak => write!(
-                f,
-                "The provided parameters for the encryption are too weak"
-            ),
-            Error::DecryptionError => {
-                write!(f, "Could not decrypt the ciphertext")
-            }
-            Error::MetadataMissing => write!(
-                f,
-                "The provided buffer does not include a metadata header"
-            ),
-            Error::MetadataInvalid => {
-                write!(f, "The provided buffer has an invalid metadata header")
-            }
-        }
-    }
 }


### PR DESCRIPTION
Use the `thiserror` crate to implement the `Error` trait for
Tindercrypt's `errors::Error` enum. As a bonus, we can remove the
implementation for the `Display` trait, since `thiserror` provides one
as well.

Closes #3