### PR TITLE
Improve key derivation in RingCryptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ Versioning].
 
 - Allow users to derive a key from a secret value and the encryption metadata.
 
+### Removed
+
+- Remove the key derivation process that was performed internally in the
+  following `RingCryptor` methods:
+
+  * `seal_in_place`
+  * `seal_with_meta`
+  * `seal_with_key`
+  * `open_in_place`
+  * `open_with_meta`
+
+  The change should impact just the users that used key derivation (PBKDF2) and
+  passed a passphrase to any of the above functions. If you are affected, you
+  can manually derive the key and pass it to the above functions. For more info,
+  see the examples in the `RingCryptor` documentation.
+
+  Note that the following methods are still performing key derivation
+  internally:
+
+  * `seal_with_passphrase`
+  * `open`
+
+  Finally, the reason for the removal was not security-related, but to give more
+  control to the users on this front ([#6]).
+
 ## [0.2.2] - 2020-04-13
 
 ### Changed
@@ -60,6 +85,7 @@ Initial release.
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
+[#6]: https://github.com/apyrgio/tindercrypt/issues/6
 
 [Unreleased]: https://github.com/apyrgio/tindercrypt/compare/v0.2.2...HEAD
 [0.2.2]: https://github.com/apyrgio/tindercrypt/compare/v0.2.1...v0.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning].
 
 ## [Unreleased]
 
+### Added
+
+- Allow users to derive a key from a secret value and the encryption metadata.
+
 ## [0.2.2] - 2020-04-13
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,7 @@ dependencies = [
  "rand",
  "ring",
  "thiserror",
+ "zeroize",
 ]
 
 [[package]]
@@ -816,3 +817,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "zeroize"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ rand = "0.7"
 # [1]: https://github.com/briansmith/ring#versioning--stability
 ring = "0.16"
 thiserror = "1"
+zeroize = "1"
 
 # NOTE: The following dependencies are required only for the CLI version of the
 # crate, and are only included if the `cli` feature is enabled. See also

--- a/src/cryptors.rs
+++ b/src/cryptors.rs
@@ -473,6 +473,12 @@ impl<'a> RingCryptor<'a> {
     /// This method copies the ciphertext to a new buffer and decrypts (opens)
     /// it in place. Then, it returns the buffer with the plaintext. This way,
     /// the ciphertext is preserved, at the cost of an extra copy.
+    ///
+    /// **Note:** By "ciphertext" we don't refer to the whole buffer that the
+    /// `seal_*` methods produce. We refer to the part with the encrypted
+    /// payload, which does not include the metadata. For more info on how to
+    /// extract this part, see the examples in the [`RingCryptor`]
+    /// documentation.
     pub fn open_with_meta(
         &self,
         meta: &metadata::Metadata,

--- a/src/cryptors.rs
+++ b/src/cryptors.rs
@@ -7,7 +7,6 @@
 //!
 //! [`RingCryptor`]: struct.RingCryptor.html
 
-#![allow(missing_docs)]
 use crate::aead;
 use crate::errors;
 use crate::metadata;

--- a/src/cryptors.rs
+++ b/src/cryptors.rs
@@ -403,7 +403,7 @@ impl<'a> RingCryptor<'a> {
 
     /// Decrypt (open) the data buffer.
     ///
-    /// This method accepts a a secret value (either a key or a passphrase) and
+    /// This method accepts a secret value (either a key or a passphrase) and
     /// a data buffer that contains the serialized metadata and the ciphertext.
     ///
     /// It deserializes the metadata and extracts the ciphertext from the

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -543,7 +543,7 @@ impl<'a> Metadata {
         }
     }
 
-    /// Generate the necesary metadata for encrypting data with a symmetric
+    /// Generate the necessary metadata for encrypting data with a symmetric
     /// key.
     ///
     /// The default suggestion for encrypting data with a symmetric key is to
@@ -556,7 +556,7 @@ impl<'a> Metadata {
         Self::new(key_deriv_algo, enc_algo, plaintext_size)
     }
 
-    /// Generate the necesary metadata for encrypting data with a passphrase.
+    /// Generate the necessary metadata for encrypting data with a passphrase.
     ///
     /// The default suggestion for encrypting data with a passphrase is to use
     /// the PBKDF2 key derivation algorithm, and the AES-256-GCM encryption


### PR DESCRIPTION
This PR introduces the following changes to the RingCryptor interface:

1. It adds two public methods that allow the users to derive a key from a secret value and some metadata.
2. It removes key derivation from some low-level `RingCryptor` functions, while retaining it where it makes sense.

This should make key derivation less "auto-magic", and provide a solution to #6.